### PR TITLE
Support for Enthusiast's Timepiece & Quackenbirdt Chargebars

### DIFF
--- a/CastingEssentials/Modules/HUDHacking.cpp
+++ b/CastingEssentials/Modules/HUDHacking.cpp
@@ -85,6 +85,8 @@ const HUDHacking::ChargeBarInfo HUDHacking::s_ChargeBarInfo[(int)ChargeBarType::
 
 	ChargeBarInfo("spycicle", 2, "the Spy-cicle", "#TF_SpyCicle", 649, MeterType::Spycicle),
 	ChargeBarInfo("invis_watch", 1, "the Invis Watch", "#TF_Weapon_Watch", 30, MeterType::Cloak),
+	ChargeBarInfo("enthusiasts_timepiece", 1, "the Enthusiast's Timepiece", "#TF_Weapon_Watch", 297, MeterType::Cloak),
+	ChargeBarInfo("quackenbirdt", 1, "the Quackenbirdt", "#TF_Weapon_Watch", 947, MeterType::Cloak),
 	ChargeBarInfo("cloak_and_dagger", 1, "the Cloak and Dagger", "#TF_Unique_Achievement_CloakWatch", 60, MeterType::Cloak),
 	ChargeBarInfo("dead_ringer", 1, "the Dead Ringer", "#TF_Unique_Achievement_FeignWatch", 59, MeterType::Cloak),
 };

--- a/CastingEssentials/Modules/HUDHacking.h
+++ b/CastingEssentials/Modules/HUDHacking.h
@@ -91,6 +91,8 @@ private:
 
 		Spycicle,
 		InvisWatch,
+		EnthusiastsTimepiece,
+		Quackenbirdt,
 		CloakAndDagger,
 		DeadRinger,
 


### PR DESCRIPTION
I'm not too well-versed in C++, and there's probably a classier way of declaring all of the item IDs into one chargebar declaration, but this gets the job done. This implementation also allows the reskins' names to be adjusted depending on the item, though by default they all show up as the stock invis watch since they're just reskins.